### PR TITLE
Release LLVM/JIT slang-llvm working

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,49 @@ These features may include
 * Allow parsing of C/C++ code 
 * Compile Slang code to bitcode 
 * JIT execution of bitcode
+
+Building
+========
+
+Once this repo has been cloned, it is neccessary to get the dependencies needed via
+
+```
+% git submodule update --init
+```
+
+NOTE! Currently LLVM is *NOT* a submodule, and has to be built locally from source code from the [LLVM project](https://github.com/llvm/). The process of building LLVM is described in a later section.
+
+Limitiations
+============
+
+* At the moment only contains a sample 'llvm-direct' that compiles from some source to object
+* Only works on Visual Studio
+
+Building LLVM/Clang
+===================
+
+The follow the instructions for building on from source on windows. In additional to that the following need to be set
+
+The root of the project for CMAKE is actually the llvm directory in the `root` directory. Set the directory for the binaries to be `build.vs` in the `root` directory for windows. Currently the premake file assumes this name for the binaries/libs/built includes.
+
+```
+LLVM_ENABLE_PROJECTS            clang
+```
+
+Ideally we'd have LLVM/Clang not use a dll CRT, but for the moment this doesn't work. An attempt to make it work by enabling
+
+```
+LLVM_USE_CRT_DEBUG              MTd
+LLVM_USE_CRT_MINSIZEREL         MT
+LLVM_USE_CRT_RELEASE            MT
+LLVM_USE_CRT_RELWITHDEBINFO     MTd
+```
+
+These might be of importance
+
+```
+LLVM_STATIC_LINK_CXX_STDLIB
+LIBCLANG_BUILD_STATIC
+```
+
+Led to issues with multiply defined CRT symbols when building, so for now we use with dll CRT.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ The root of the project for CMAKE is actually the llvm directory in the `root` d
 
 We want a 64 bit environment it may be necessary to specify on command line
 
+(From)[https://clang.llvm.org/get_started.html], more details on the (options)[https://www.llvm.org/docs/CMake.html]
+
 ```
 -Thost=x64
 ```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ NOTE! Currently LLVM is *NOT* a submodule, and has to be built locally from sour
 Limitiations
 ============
 
-* At the moment only contains a sample 'llvm-direct' that compiles from some source to object
+* At the moment only contains a sample 'clang-direct' that compiles from some source to object
 * Only works on Visual Studio
 
 Building LLVM/Clang
@@ -36,6 +36,14 @@ Building LLVM/Clang
 The follow the instructions for building on from source on windows. In additional to that the following need to be set
 
 The root of the project for CMAKE is actually the llvm directory in the `root` directory. Set the directory for the binaries to be `build.vs` in the `root` directory for windows. Currently the premake file assumes this name for the binaries/libs/built includes.
+
+We want a 64 bit environment it may be necessary to specify on command line
+
+```
+-Thost=x64
+```
+
+We want to try and force the use of the x64 linker (as the x86 linker fails)
 
 ```
 LLVM_ENABLE_PROJECTS            clang

--- a/examples/clang-direct/main.cpp
+++ b/examples/clang-direct/main.cpp
@@ -400,6 +400,8 @@ static SlangResult _compile()
 
                 jitErrorStream << err;
 
+                printf("Unable to create JIT: %s\n", jitErrorString.c_str());
+
                 return SLANG_FAIL;
             }
             jit = std::move(*expectJit); 

--- a/examples/clang-direct/main.cpp
+++ b/examples/clang-direct/main.cpp
@@ -64,15 +64,6 @@
 
 #include <stdio.h>
 
-// We want to make math functions available to the JIT
-#if SLANG_GCC_FAMILY && __GNUC__ < 6
-#   include <cmath>
-#   define SLANG_LLVM_STD std::
-#else
-#   include <math.h>
-#   define SLANG_LLVM_STD
-#endif
-
 namespace slang_clang {
 
 using namespace clang;
@@ -145,129 +136,9 @@ public:
     Slang::List<Entry> m_entries;
 };
 
-/*
-* A question is how to make the prototypes available for these functions. They would need to be defined before the
-* the prelude - or potentially in the prelude.
-*
-* I could just define the prototypes in the prelude, and only impl, if needed. Here though I require that all the functions
-* implemented here, use C style names (ie unmanagled) to simplify lookup.
-*/
-
-struct NameAndFunc
-{
-    typedef void (*Func)();
-
-    const char* name;
-    Func func;
-};
-
-#define SLANG_LLVM_EXPAND(x) x
-
-#define SLANG_LLVM_FUNC(name, cppName, retType, paramTypes) NameAndFunc{ #name, (NameAndFunc::Func)static_cast<retType (*) paramTypes>(&SLANG_LLVM_EXPAND(cppName)) },
-
-// Implementations of maths functions available to JIT
-static float F32_frexp(float x, float* e)
-{
-    int ei;
-    float m = ::frexpf(x, &ei);
-    *e = float(ei);
-    return m;
-}
-
-static double F64_frexp(double x, double* e)
-{
-    int ei;
-    double m = ::frexp(x, &ei);
-    *e = float(ei);
-    return m;
-}
-
-// These are only the functions that cannot be implemented with 'reasonable performance' in the prelude.
-// It is assumed that calling from JIT to C function whilst not super expensive, is an issue. 
-
-// name, cppName, retType, paramTypes
-#define SLANG_LLVM_FUNCS(x) \
-    x(F64_ceil, ceil, double, (double)) \
-    x(F64_floor, floor, double, (double)) \
-    x(F64_round, round, double, (double)) \
-    x(F64_sin, sin, double, (double)) \
-    x(F64_cos, cos, double, (double)) \
-    x(F64_tan, tan, double, (double)) \
-    x(F64_asin, asin, double, (double)) \
-    x(F64_acos, acos, double, (double)) \
-    x(F64_atan, atan, double, (double)) \
-    x(F64_sinh, sinh, double, (double)) \
-    x(F64_cosh, cosh, double, (double)) \
-    x(F64_tanh, tanh, double, (double)) \
-    x(F64_log2, log2, double, (double)) \
-    x(F64_log, log, double, (double)) \
-    x(F64_log10, log10, double, (double)) \
-    x(F64_exp2, exp2, double, (double)) \
-    x(F64_exp, exp, double, (double)) \
-    x(F64_fabs, fabs, double, (double)) \
-    x(F64_trunc, trunc, double, (double)) \
-    x(F64_sqrt, sqrt, double, (double)) \
-    \
-    x(F64_isnan, SLANG_LLVM_STD isnan, bool, (double)) \
-    x(F64_isfinite, SLANG_LLVM_STD isfinite, bool, (double)) \
-    x(F64_isinf, SLANG_LLVM_STD isinf, bool, (double)) \
-    \
-    x(F64_atan2, atan2, double, (double, double)) \
-    \
-    x(F64_frexp, F64_frexp, double, (double, double*)) \
-    x(F64_pow, pow, double, (double, double)) \
-    \
-    x(F64_modf, modf, double, (double, double*)) \
-    x(F64_fmod, fmod, double, (double, double)) \
-    x(F64_remainder, remainder, double, (double, double)) \
-    \
-    x(F32_ceil, ceilf, float, (float)) \
-    x(F32_floor, floorf, float, (float)) \
-    x(F32_round, roundf, float, (float)) \
-    x(F32_sin, sinf, float, (float)) \
-    x(F32_cos, cosf, float, (float)) \
-    x(F32_tan, tanf, float, (float)) \
-    x(F32_asin, asinf, float, (float)) \
-    x(F32_acos, acosf, float, (float)) \
-    x(F32_atan, atanf, float, (float)) \
-    x(F32_sinh, sinhf, float, (float)) \
-    x(F32_cosh, coshf, float, (float)) \
-    x(F32_tanh, tanhf, float, (float)) \
-    x(F32_log2, log2f, float, (float)) \
-    x(F32_log, logf, float, (float)) \
-    x(F32_log10, log10f, float, (float)) \
-    x(F32_exp2, exp2f, float, (float)) \
-    x(F32_exp, expf, float, (float)) \
-    x(F32_fabs, fabsf, float, (float)) \
-    x(F32_trunc, truncf, float, (float)) \
-    x(F32_sqrt, sqrtf, float, (float)) \
-    \
-    x(F32_isnan, SLANG_LLVM_STD isnan, bool, (float)) \
-    x(F32_isfinite, SLANG_LLVM_STD isfinite, bool, (float)) \
-    x(F32_isinf, SLANG_LLVM_STD isinf, bool, (float)) \
-    \
-    x(F32_atan2, atan2f, float, (float, float)) \
-    \
-    x(F32_frexp, F32_frexp, float, (float, float*)) \
-    x(F32_pow, powf, float, (float, float)) \
-    \
-    x(F32_modf, modff, float, (float, float*)) \
-    x(F32_fmod, fmodf, float, (float, float)) \
-    x(F32_remainder, remainderf, float, (float, float)) 
-
-static void _appendBuiltinPrototypes(Slang::StringBuilder& out)
-{
-    // Make all function names unmangled that are implemented externally.
-    out << "extern \"C\" { \n";
-
-#define SLANG_LLVM_APPEND_PROTOTYPE(name, cppName, retType, paramTypes)     out << #retType << " " << #name << #paramTypes << ";\n";
-    SLANG_LLVM_FUNCS(SLANG_LLVM_APPEND_PROTOTYPE)
-
-    out << "}\n\n";
-}
-
 static const char cppSource[] =
-    "extern \"C\" double doSin(double f) { return F64_sin(f); }\n"
+    "extern \"C\" double sin(double);\n "
+    "extern \"C\" double doSin(double f) { return sin(f); }\n"
     "extern \"C\" int add(int a, int b) { return a + b; } int main() { return 0; }";
 
 static SlangResult _compile()
@@ -307,8 +178,6 @@ static SlangResult _compile()
     IntrusiveRefCntPtr<DiagnosticsEngine> diags = new DiagnosticsEngine(diagID, diagOpts, &diagsBuffer, false);
 
     Slang::StringBuilder source;
-    _appendBuiltinPrototypes(source);
-    source << "\n\n";
     source << cppSource;
 
     StringRef sourceStringRef(source.getBuffer(), source.getLength());
@@ -524,6 +393,13 @@ static SlangResult _compile()
             Expected<std::unique_ptr< llvm::orc::LLJIT>> expectJit = jitBuilder.create();
             if (!expectJit)
             {
+                auto err = expectJit.takeError();
+
+                std::string jitErrorString;
+                llvm::raw_string_ostream jitErrorStream(jitErrorString);
+
+                jitErrorStream << err;
+
                 return SLANG_FAIL;
             }
             jit = std::move(*expectJit); 
@@ -548,19 +424,7 @@ static SlangResult _compile()
 
                 // Add all the symbolmap
                 SymbolMap symbolMap;
-
-                //symbolMap.insert(std::make_pair(mangler("sin"), JITEvaluatedSymbol::fromPointer(static_cast<double (*)(double)>(&sin))));
-
-                const NameAndFunc funcs[] =
-                {
-                    SLANG_LLVM_FUNCS(SLANG_LLVM_FUNC)
-                };
-
-                for (auto& func : funcs)
-                {
-                    symbolMap.insert(std::make_pair(mangler(func.name), JITEvaluatedSymbol::fromPointer(func.func)));
-                }
-
+                symbolMap.insert(std::make_pair(mangler("sin"), JITEvaluatedSymbol::fromPointer(static_cast<double (*)(double)>(&sin))));
                 stdcLib.define(absoluteSymbols(symbolMap));
 
                 // Required or the symbols won't be found

--- a/examples/clang-direct/main.cpp
+++ b/examples/clang-direct/main.cpp
@@ -387,10 +387,14 @@ static SlangResult _compile()
         std::unique_ptr<llvm::orc::LLJIT> jit;
         {
             // Create the JIT
-
             LLJITBuilder jitBuilder;
 
-            Expected<std::unique_ptr< llvm::orc::LLJIT>> expectJit = jitBuilder.create();
+            // Defaults to the 'system' that this library was compiled with. For our purposes here, this is fine.
+            
+            // This can fail with "Unable to find target for this triple (no targets are registered)".
+            // The error is actually from TargetRegistry
+
+            Expected<std::unique_ptr<llvm::orc::LLJIT>> expectJit = jitBuilder.create();
             if (!expectJit)
             {
                 auto err = expectJit.takeError();
@@ -449,7 +453,7 @@ static SlangResult _compile()
             Func func = (Func)add.getAddress();
             int result = func(1, 3);
 
-            SLANG_ASSERT(result == 4);
+            SLANG_RELEASE_ASSERT(result == 4);
         }
 
         auto doSinExpected = jit->lookup("doSin");
@@ -461,7 +465,7 @@ static SlangResult _compile()
 
             double result = func(0.5);
 
-            SLANG_ASSERT(result == ::sin(0.5));
+            SLANG_RELEASE_ASSERT(result == ::sin(0.5));
         }
     }
 

--- a/premake5.lua
+++ b/premake5.lua
@@ -188,12 +188,16 @@ newoption {
    description = "The path to the build directory for LLVM",
    value       = "string"
 }
+newoption {
+   trigger     = "slang-path",
+   description = "The path to the Slang, defaults to external/slang",
+   value       = "string",
+   default     = "external/slang"
+}
 
 targetDetail = _OPTIONS["target-detail"]
 llvmPath = _OPTIONS["llvm-path"]
-
---slangPath = "external/slang"
-slangPath = "E:/git/slang-jsmall-nvidia"
+slangPath = _OPTIONS["slang-path"]
 
 if not llvmPath then
     print("llvm-path option must be set")

--- a/premake5.lua
+++ b/premake5.lua
@@ -576,7 +576,7 @@ standardProject("core", path.join(slangPath, "source/core"))
         addSourceDir(path.join(slangPath, "source/core/unix"))
     end
     
-standardProject("compiler-core", "source/compiler-core")
+standardProject("compiler-core", path.join(slangPath, "source/compiler-core"))
     uuid "12C1E89D-F5D0-41D3-8E8D-FB3F358F8126"
     kind "StaticLib"
     -- We need the compiler-core library to be relocatable to be able to link with slang.so
@@ -598,15 +598,17 @@ standardProject("compiler-core", "source/compiler-core")
         addSourceDir(path.join(slangPath, "source/compiler-core/unix"))
     end
 
-
 standardProject("slang-llvm", "source/slang-llvm")
     uuid "F74A3AF1-5F0B-4EDF-AD43-04DABE9CDC75"
     kind "SharedLib"
     warnings "Extra"
     flags { "FatalWarnings" }
     pic "On"
+
+    links { "core", "compiler-core" }
     
-    includedirs {
+    includedirs 
+    {
         -- So we can access slang.h
         slangPath, 
         -- For core/compiler-core
@@ -622,8 +624,8 @@ standardProject("slang-llvm", "source/slang-llvm")
         -- Disable warnings that are a problem on LLVM/Clang on windows
         disablewarnings(disableWarningsList) 
         -- LLVM/Clang need this system library
-        links { "version" }
-    
+        links { "version" } 
+        
     filter { "configurations:debug" }    
         local libPath = path.join(llvmBuildPath, "Debug/lib")
         libdirs { libPath }
@@ -636,7 +638,5 @@ standardProject("slang-llvm", "source/slang-llvm")
         libdirs { libPath }
         -- We need to vary this depending on type
         links(findLibraries(libPath, "clang*", isClangLibraryName))
-        links(findLibraries(libPath,"LLVM*"))
-    
-    links { "core", "compiler-core" }
-    
+        links(findLibraries(libPath,"LLVM*")) 
+

--- a/source/slang-llvm/slang-llvm.cpp
+++ b/source/slang-llvm/slang-llvm.cpp
@@ -725,16 +725,20 @@ SlangResult LLVMDownstreamCompiler::compile(const CompileOptions& options, RefPt
 
                     DownstreamDiagnostic diagnostic;
 
+                    StringBuilder buf;
+                    buf << "Unable to create JIT engine: " << jitErrorString.c_str();
+
                     diagnostic.severity = DownstreamDiagnostic::Severity::Error;
                     diagnostic.stage = DownstreamDiagnostic::Stage::Link;
-                    diagnostic.text = jitErrorString.c_str();
+                    diagnostic.text = buf.ProduceString();
                     diagnostic.fileLine = 0;
 
                     // Add the error
                     diagsBuffer.m_diagnostics.diagnostics.add(diagnostic);
+                    diagsBuffer.m_diagnostics.result = SLANG_FAIL;
 
                     outResult = new BlobDownstreamCompileResult(diagsBuffer.m_diagnostics, nullptr);
-                    return SLANG_FAIL;
+                    return SLANG_OK;
                 }
                 jit = std::move(*expectJit);
             }

--- a/source/slang-llvm/slang-llvm.cpp
+++ b/source/slang-llvm/slang-llvm.cpp
@@ -716,6 +716,22 @@ SlangResult LLVMDownstreamCompiler::compile(const CompileOptions& options, RefPt
                 Expected<std::unique_ptr< llvm::orc::LLJIT>> expectJit = jitBuilder.create();
                 if (!expectJit)
                 {
+                    /* JS: NOTE!
+                    
+                    It is worth saying there can be some odd issues around creating the JIT - if LLVM-C is linked against.
+                    
+                    If it is then LLVM will likely startup saying LLVM-C isn't found.
+                    BUT if you have LLVM *installed* on your system (as is reasonable to do from a LLVM distro, then
+                    at startup it *MIGHT* find a LLVM-C dll in that installation (ie nothing to do with the version of LLVM
+                    linked with). This will likely lead to an odd error saying the 'triple can't be found' and that no
+                    targets are registered.
+
+                    Also note that the behavior *may* be different with Debug/Release - because of how the linked resolves symbols
+                    that are multiply defined.
+
+                    If there are problems creating the JIT, check that LLVM-C is not linked against (it should be disabled in the premake).
+                    */
+
                     auto err = expectJit.takeError();
 
                     std::string jitErrorString;

--- a/source/slang-llvm/slang-llvm.cpp
+++ b/source/slang-llvm/slang-llvm.cpp
@@ -1,0 +1,723 @@
+
+#include "clang/Basic/Stack.h"
+#include "clang/Basic/TargetOptions.h"
+#include "clang/CodeGen/ObjectFilePCHContainerOperations.h"
+#include "clang/Config/config.h"
+#include "clang/Driver/DriverDiagnostic.h"
+#include "clang/Driver/Options.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/CompilerInvocation.h"
+#include "clang/Frontend/FrontendDiagnostic.h"
+#include "clang/Frontend/TextDiagnosticBuffer.h"
+#include "clang/Frontend/TextDiagnosticPrinter.h"
+#include "clang/Frontend/Utils.h"
+#include "clang/FrontendTool/Utils.h"
+
+#include "clang/Frontend/FrontendAction.h"
+#include "clang/CodeGen/CodeGenAction.h"
+#include "clang/Basic/Version.h"
+
+#include "llvm/ADT/Statistic.h"
+#include "llvm/Config/llvm-config.h"
+#include "llvm/LinkAllPasses.h"
+#include "llvm/Option/Arg.h"
+#include "llvm/Option/ArgList.h"
+#include "llvm/Option/OptTable.h"
+#include "llvm/Support/BuryPointer.h"
+#include "llvm/Support/Compiler.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/ManagedStatic.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/Process.h"
+#include "llvm/Support/Signals.h"
+#include "llvm/Support/TargetRegistry.h"
+#include "llvm/Support/TargetSelect.h"
+#include "llvm/Support/TimeProfiler.h"
+#include "llvm/Support/Timer.h"
+
+#include "llvm/Support/raw_ostream.h"
+
+#include "llvm/Target/TargetMachine.h"
+
+// Jit
+#include "llvm/ExecutionEngine/JITEventListener.h"
+#include "llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h"
+
+#include "llvm/ExecutionEngine/Orc/ExecutionUtils.h"
+#include "llvm/ExecutionEngine/Orc/LLJIT.h"
+
+#include "llvm/ExecutionEngine/Orc/ThreadSafeModule.h"
+
+#include "llvm/ExecutionEngine/JITSymbol.h"
+
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IRReader/IRReader.h"
+
+// Slang
+
+#include <slang.h>
+#include <slang-com-helper.h>
+#include <slang-com-ptr.h>
+
+#include <core/slang-list.h>
+#include <core/slang-string.h>
+
+#include <compiler-core/slang-downstream-compiler.h>
+
+#include <stdio.h>
+
+// We want to make math functions available to the JIT
+#if SLANG_GCC_FAMILY && __GNUC__ < 6
+#   include <cmath>
+#   define SLANG_LLVM_STD std::
+#else
+#   include <math.h>
+#   define SLANG_LLVM_STD
+#endif
+
+namespace slang_clang {
+
+using namespace clang;
+
+using namespace llvm::opt;
+using namespace llvm;
+using namespace llvm::orc;
+
+using namespace Slang;
+
+class LLVMDownstreamCompiler : public DownstreamCompiler
+{
+public:
+    typedef DownstreamCompiler Super;
+
+    /// Compile using the specified options. The result is in resOut
+    virtual SlangResult compile(const CompileOptions& options, RefPtr<DownstreamCompileResult>& outResult) = 0;
+    virtual SlangResult disassemble(SlangCompileTarget sourceBlobTarget, const void* blob, size_t blobSize, ISlangBlob** out) SLANG_OVERRIDE;
+
+    virtual bool isFileBased() SLANG_OVERRIDE { return false; }
+
+    LLVMDownstreamCompiler()
+    {
+        Desc desc;
+
+        desc.type = SLANG_PASS_THROUGH_LLVM;
+        desc.majorVersion = LLVM_VERSION_MAJOR;
+        desc.minorVersion = LLVM_VERSION_MINOR;
+
+        m_desc = desc;
+    }
+};
+
+SlangResult LLVMDownstreamCompiler::disassemble(SlangCompileTarget sourceBlobTarget, const void* blob, size_t blobSize, ISlangBlob** out)
+{
+    return SLANG_E_NOT_IMPLEMENTED;
+}
+
+
+class LLVMDownstreamCompileResult : public ISlangSharedLibrary, public DownstreamCompileResult
+{
+public:
+    typedef DownstreamCompileResult Super;
+
+    // ISlangUnknown
+    virtual SLANG_NO_THROW SlangResult SLANG_MCALL queryInterface(SlangUUID const& uuid, void** outObject) SLANG_OVERRIDE;
+    SLANG_REF_OBJECT_IUNKNOWN_ADD_REF
+    SLANG_REF_OBJECT_IUNKNOWN_RELEASE
+
+    // ISlangSharedLibrary impl
+    virtual SLANG_NO_THROW void* SLANG_MCALL findSymbolAddressByName(char const* name) SLANG_OVERRIDE;
+
+    // DownstreamCompileResult impl
+    virtual SlangResult getHostCallableSharedLibrary(ComPtr<ISlangSharedLibrary>& outLibrary) SLANG_OVERRIDE;
+    virtual SlangResult getBinary(ComPtr<ISlangBlob>& outBlob) SLANG_OVERRIDE { return SLANG_E_NOT_IMPLEMENTED;  }
+
+    LLVMDownstreamCompileResult(DownstreamDiagnostics& diagnostics,
+        std::unique_ptr<llvm::orc::LLJIT> jit) :
+        Super(diagnostics),
+        m_jit(std::move(jit))
+    {
+    }
+
+protected:
+    ISlangUnknown* LLVMDownstreamCompileResult::getInterface(const Guid& guid);
+
+    std::unique_ptr<llvm::orc::LLJIT> m_jit;
+};
+
+SLANG_NO_THROW void* SLANG_MCALL LLVMDownstreamCompileResult::findSymbolAddressByName(char const* name) 
+{
+    auto fnExpected = m_jit->lookup(name);
+    if (fnExpected)
+    {
+        auto fn = std::move(*fnExpected);
+        return (void*)fn.getAddress();
+    }
+    return nullptr;
+}
+
+ISlangUnknown* LLVMDownstreamCompileResult::getInterface(const Guid& guid)
+{
+    return guid == ISlangUnknown::getTypeGuid() || guid == ISlangSharedLibrary::getTypeGuid() ? static_cast<ISlangSharedLibrary*>(this) : nullptr;
+}
+
+
+static void _ensureSufficientStack() {}
+
+static void _llvmErrorHandler(void* userData, const std::string& message, bool genCrashDiag)
+{
+    DiagnosticsEngine& diags = *static_cast<DiagnosticsEngine*>(userData);
+    diags.Report(diag::err_fe_error_backend) << message;
+
+    // Run the interrupt handlers to make sure any special cleanups get done, in
+    // particular that we remove files registered with RemoveFileOnSignal.
+    llvm::sys::RunInterruptHandlers();
+
+    // We cannot recover from llvm errors.  (!)
+    // 
+    // Returning nothing, will still cause LLVM to exit the process.
+}
+
+static Slang::DownstreamDiagnostic::Severity _getSeverity(DiagnosticsEngine::Level level)
+{
+    typedef DownstreamDiagnostic::Severity Severity;
+    typedef DiagnosticsEngine::Level Level;
+    switch (level)
+    {
+        default:
+        case Level::Ignored:
+        case Level::Note:
+        case Level::Remark:
+        {
+            return Severity::Info;
+        }
+        case Level::Warning:
+        {
+            return Severity::Warning;
+        }
+        case Level::Error:
+        case Level::Fatal:
+        {
+            return Severity::Error;
+        }
+    }
+}
+
+class BufferedDiagnosticConsumer : public clang::DiagnosticConsumer
+{
+public:
+
+    void HandleDiagnostic(DiagnosticsEngine::Level level, const Diagnostic& info) override
+    {
+
+        SmallString<100> text;
+        info.FormatDiagnostic(text);
+
+        DownstreamDiagnostic diagnostic;
+        diagnostic.severity = _getSeverity(level);
+        diagnostic.stage = DownstreamDiagnostic::Stage::Compile;
+        diagnostic.text = text.c_str();
+
+        auto location = info.getLocation();
+
+        // Work out what the location is
+        auto& sourceManager = info.getSourceManager();
+
+        // Gets the file/line number 
+        const bool useLineDirectives = true;
+        const PresumedLoc presumedLoc = sourceManager.getPresumedLoc(location, useLineDirectives);
+
+        diagnostic.fileLine = presumedLoc.getLine();
+        diagnostic.filePath = presumedLoc.getFilename();
+
+        m_diagnostics.diagnostics.add(diagnostic);
+    }
+
+    bool hasError() const { return m_diagnostics.getCountByMinSeverity(DownstreamDiagnostic::Severity::Error) > 0; }
+
+    DownstreamDiagnostics m_diagnostics;
+};
+
+/*
+* A question is how to make the prototypes available for these functions. They would need to be defined before the
+* the prelude - or potentially in the prelude.
+*
+* I could just define the prototypes in the prelude, and only impl, if needed. Here though I require that all the functions
+* implemented here, use C style names (ie unmanagled) to simplify lookup.
+*/
+
+struct NameAndFunc
+{
+    typedef void (*Func)();
+
+    const char* name;
+    Func func;
+};
+
+#define SLANG_LLVM_EXPAND(x) x
+
+#define SLANG_LLVM_FUNC(name, cppName, retType, paramTypes) NameAndFunc{ #name, (NameAndFunc::Func)static_cast<retType (*) paramTypes>(&SLANG_LLVM_EXPAND(cppName)) },
+
+// Implementations of maths functions available to JIT
+static float F32_frexp(float x, float* e)
+{
+    int ei;
+    float m = ::frexpf(x, &ei);
+    *e = float(ei);
+    return m;
+}
+
+static double F64_frexp(double x, double* e)
+{
+    int ei;
+    double m = ::frexp(x, &ei);
+    *e = float(ei);
+    return m;
+}
+
+// These are only the functions that cannot be implemented with 'reasonable performance' in the prelude.
+// It is assumed that calling from JIT to C function whilst not super expensive, is an issue. 
+
+// name, cppName, retType, paramTypes
+#define SLANG_LLVM_FUNCS(x) \
+    x(F64_ceil, ceil, double, (double)) \
+    x(F64_floor, floor, double, (double)) \
+    x(F64_round, round, double, (double)) \
+    x(F64_sin, sin, double, (double)) \
+    x(F64_cos, cos, double, (double)) \
+    x(F64_tan, tan, double, (double)) \
+    x(F64_asin, asin, double, (double)) \
+    x(F64_acos, acos, double, (double)) \
+    x(F64_atan, atan, double, (double)) \
+    x(F64_sinh, sinh, double, (double)) \
+    x(F64_cosh, cosh, double, (double)) \
+    x(F64_tanh, tanh, double, (double)) \
+    x(F64_log2, log2, double, (double)) \
+    x(F64_log, log, double, (double)) \
+    x(F64_log10, log10, double, (double)) \
+    x(F64_exp2, exp2, double, (double)) \
+    x(F64_exp, exp, double, (double)) \
+    x(F64_fabs, fabs, double, (double)) \
+    x(F64_trunc, trunc, double, (double)) \
+    x(F64_sqrt, sqrt, double, (double)) \
+    \
+    x(F64_isnan, SLANG_LLVM_STD isnan, bool, (double)) \
+    x(F64_isfinite, SLANG_LLVM_STD isfinite, bool, (double)) \
+    x(F64_isinf, SLANG_LLVM_STD isinf, bool, (double)) \
+    \
+    x(F64_atan2, atan2, double, (double, double)) \
+    \
+    x(F64_frexp, F64_frexp, double, (double, double*)) \
+    x(F64_pow, pow, double, (double, double)) \
+    \
+    x(F64_modf, modf, double, (double, double*)) \
+    x(F64_fmod, fmod, double, (double, double)) \
+    x(F64_remainder, remainder, double, (double, double)) \
+    \
+    x(F32_ceil, ceilf, float, (float)) \
+    x(F32_floor, floorf, float, (float)) \
+    x(F32_round, roundf, float, (float)) \
+    x(F32_sin, sinf, float, (float)) \
+    x(F32_cos, cosf, float, (float)) \
+    x(F32_tan, tanf, float, (float)) \
+    x(F32_asin, asinf, float, (float)) \
+    x(F32_acos, acosf, float, (float)) \
+    x(F32_atan, atanf, float, (float)) \
+    x(F32_sinh, sinhf, float, (float)) \
+    x(F32_cosh, coshf, float, (float)) \
+    x(F32_tanh, tanhf, float, (float)) \
+    x(F32_log2, log2f, float, (float)) \
+    x(F32_log, logf, float, (float)) \
+    x(F32_log10, log10f, float, (float)) \
+    x(F32_exp2, exp2f, float, (float)) \
+    x(F32_exp, expf, float, (float)) \
+    x(F32_fabs, fabsf, float, (float)) \
+    x(F32_trunc, truncf, float, (float)) \
+    x(F32_sqrt, sqrtf, float, (float)) \
+    \
+    x(F32_isnan, SLANG_LLVM_STD isnan, bool, (float)) \
+    x(F32_isfinite, SLANG_LLVM_STD isfinite, bool, (float)) \
+    x(F32_isinf, SLANG_LLVM_STD isinf, bool, (float)) \
+    \
+    x(F32_atan2, atan2f, float, (float, float)) \
+    \
+    x(F32_frexp, F32_frexp, float, (float, float*)) \
+    x(F32_pow, powf, float, (float, float)) \
+    \
+    x(F32_modf, modff, float, (float, float*)) \
+    x(F32_fmod, fmodf, float, (float, float)) \
+    x(F32_remainder, remainderf, float, (float, float)) 
+
+static void _appendBuiltinPrototypes(Slang::StringBuilder& out)
+{
+    // Make all function names unmangled that are implemented externally.
+    out << "extern \"C\" { \n";
+
+#define SLANG_LLVM_APPEND_PROTOTYPE(name, cppName, retType, paramTypes)     out << #retType << " " << #name << #paramTypes << ";\n";
+    SLANG_LLVM_FUNCS(SLANG_LLVM_APPEND_PROTOTYPE)
+
+        out << "}\n\n";
+}
+
+static int _getOptimizationLevel(DownstreamCompiler::OptimizationLevel level)
+{
+    typedef DownstreamCompiler::OptimizationLevel OptimizationLevel;
+    switch (level)
+    {
+        case OptimizationLevel::None:     return 0;
+        default:
+        case OptimizationLevel::Default:  return 1;
+        case OptimizationLevel::High:     return 2;
+        case OptimizationLevel::Maximal:  return 3;
+    }
+}
+
+static SlangResult _initLLVM()
+{
+    // Initialize targets first, so that --version shows registered targets.
+#if 0
+    llvm::InitializeAllTargets();
+    llvm::InitializeAllTargetMCs();
+    llvm::InitializeAllAsmPrinters();
+    llvm::InitializeAllAsmParsers();
+#else
+    // Just initialize items needed for this target.
+
+    llvm::InitializeNativeTarget();
+    llvm::InitializeNativeTargetAsmPrinter();
+    llvm::InitializeNativeTargetAsmParser();
+
+    llvm::InitializeNativeTargetDisassembler();
+#endif
+
+    return SLANG_OK;
+}
+
+SlangResult LLVMDownstreamCompiler::compile(const CompileOptions& options, RefPtr<DownstreamCompileResult>& outResult)
+{
+    _ensureSufficientStack();
+
+    static const SlangResult initLLVMResult = _initLLVM();
+    SLANG_RETURN_ON_FAIL(initLLVMResult);
+
+    std::unique_ptr<CompilerInstance> clang(new CompilerInstance());
+    IntrusiveRefCntPtr<DiagnosticIDs> diagID(new DiagnosticIDs());
+
+    // Register the support for object-file-wrapped Clang modules.
+    auto pchOps = clang->getPCHContainerOperations();
+    pchOps->registerWriter(std::make_unique<ObjectFilePCHContainerWriter>());
+    pchOps->registerReader(std::make_unique<ObjectFilePCHContainerReader>());
+
+    IntrusiveRefCntPtr<DiagnosticOptions> diagOpts = new DiagnosticOptions();
+
+    // TODO(JS): We might just want this to talk directly to the listener.
+    // For now we just buffer up. 
+    BufferedDiagnosticConsumer diagsBuffer;
+
+    IntrusiveRefCntPtr<DiagnosticsEngine> diags = new DiagnosticsEngine(diagID, diagOpts, &diagsBuffer, false);
+
+    //Slang::StringBuilder source;
+    //_appendBuiltinPrototypes(source);
+    //source << "\n\n";
+    //source << cppSource;
+
+    const auto& source = options.sourceContents;
+    StringRef sourceStringRef(source.getBuffer(), source.getLength());
+
+    auto sourceBuffer = llvm::MemoryBuffer::getMemBuffer(sourceStringRef);
+
+    auto& invocation = clang->getInvocation();
+
+    std::string verboseOutputString;
+
+    // Capture all of the verbose output into a buffer, so not writen to stdout
+    clang->setVerboseOutputStream(std::make_unique<llvm::raw_string_ostream>(verboseOutputString));
+
+    SmallVector<char> output;
+    clang->setOutputStream(std::make_unique<llvm::raw_svector_ostream>(output));
+
+    frontend::ActionKind action = frontend::ActionKind::EmitLLVMOnly;
+
+    // EmitCodeGenOnly doesn't appear to actually emit anything
+    // EmitLLVM outputs LLVM assembly
+    // EmitLLVMOnly doesn't 'emit' anything, but the IR that is produced is accessible, from the 'action'.
+
+    action = frontend::ActionKind::EmitLLVMOnly;
+
+    //action = frontend::ActionKind::EmitBC;
+    //action = frontend::ActionKind::EmitLLVM;
+    // 
+    //action = frontend::ActionKind::EmitCodeGenOnly;
+    //action = frontend::ActionKind::EmitObj;
+    //action = frontend::ActionKind::EmitAssembly;
+
+    {
+        auto& opts = invocation.getFrontendOpts();
+
+        // Add the source
+        // TODO(JS): For the moment this kind of include does *NOT* show a input source filename
+        // not super surprising as one isn't set, but it's not clear how one would be set when the input is a memory buffer.
+        // For Slang usage, this probably isn't an issue, because it's *output* typically holds #line directives.
+        {
+            InputKind inputKind(Language::CXX, InputKind::Format::Source);
+            FrontendInputFile inputFile(*sourceBuffer, inputKind);
+
+            opts.Inputs.push_back(inputFile);
+        }
+
+        opts.ProgramAction = action;
+    }
+
+    {
+        auto opts = invocation.getLangOpts();
+
+        switch (options.sourceLanguage)
+        {
+            case SLANG_SOURCE_LANGUAGE_CPP:
+            {
+                opts->Bool = 1;
+                opts->CPlusPlus = 1;
+                opts->LangStd = LangStandard::Kind::lang_cxx11;
+                break;
+            }
+            case SLANG_SOURCE_LANGUAGE_C:
+            {
+                opts->Bool = 1;
+                opts->LangStd = LangStandard::Kind::lang_c17;
+                break;
+            }
+            default:    return SLANG_E_NOT_AVAILABLE;
+        }
+    }
+
+    {
+        auto& opts = invocation.getHeaderSearchOpts();
+
+        // These only work if the resource directory is setup (or a virtual file system points to it)
+        opts.UseBuiltinIncludes = true;
+        opts.UseStandardSystemIncludes = true;
+        opts.UseStandardCXXIncludes = true;
+
+        /// Use libc++ instead of the default libstdc++.
+        //opts.UseLibcxx = true;
+    }
+
+    llvm::Triple targetTriple;
+    {
+        auto& opts = invocation.getTargetOpts();
+
+        opts.Triple = LLVM_DEFAULT_TARGET_TRIPLE;
+
+        // A code model isn't set by default, "default" seems to fit the bill here 
+        opts.CodeModel = "default";
+
+        targetTriple = llvm::Triple(opts.Triple);
+    }
+
+    {
+        auto& opts = invocation.getCodeGenOpts();
+
+        // Set to -O optimization level
+        opts.OptimizationLevel = _getOptimizationLevel(options.optimizationLevel);
+
+        // Copy over the targets CodeModel
+        opts.CodeModel = invocation.getTargetOpts().CodeModel;
+    }
+
+    //const llvm::opt::OptTable& opts = clang::driver::getDriverOptTable();
+
+    // TODO(JS): Need a way to find in system search paths, for now we just don't bother
+    //
+    // The system search paths are for includes for compiler intrinsics it seems. 
+    // Infer the builtin include path if unspecified.
+#if 0
+    {
+        auto& searchOpts = clang->getHeaderSearchOpts();
+        if (searchOpts.UseBuiltinIncludes && searchOpts.ResourceDir.empty())
+        {
+            // TODO(JS): Hack - hard coded path such that we can test out the
+            // resource directory functionality.
+
+            StringRef binaryPath = "F:/dev/llvm-12.0/llvm-project-llvmorg-12.0.1/build.vs/Release/bin";
+
+            // Dir is bin/ or lib/, depending on where BinaryPath is.
+
+            // On Windows, libclang.dll is in bin/.
+            // On non-Windows, libclang.so/.dylib is in lib/.
+            // With a static-library build of libclang, LibClangPath will contain the
+            // path of the embedding binary, which for LLVM binaries will be in bin/.
+            // ../lib gets us to lib/ in both cases.
+            SmallString<128> path = llvm::sys::path::parent_path(binaryPath);
+            llvm::sys::path::append(path, Twine("lib") + CLANG_LIBDIR_SUFFIX, "clang", CLANG_VERSION_STRING);
+
+            searchOpts.ResourceDir = path.c_str();
+        }
+    }
+#endif
+
+    // Create the actual diagnostics engine.
+    clang->createDiagnostics();
+    clang->setDiagnostics(diags.get());
+
+    if (!clang->hasDiagnostics())
+        return SLANG_FAIL;
+
+    //
+    clang->createFileManager();
+    clang->createSourceManager(clang->getFileManager());
+
+    // Set an error handler, so that any LLVM backend diagnostics go through our
+    // error handler.
+    llvm::install_fatal_error_handler(_llvmErrorHandler, static_cast<void*>(&clang->getDiagnostics()));
+
+    std::unique_ptr<LLVMContext> llvmContext = std::make_unique<LLVMContext>();
+
+    clang::CodeGenAction* codeGenAction = nullptr;
+    std::unique_ptr<FrontendAction> act;
+
+    {
+        // If we are going to just emit IR, we need to have access to the underlying type
+        if (action == frontend::ActionKind::EmitLLVMOnly)
+        {
+            EmitLLVMOnlyAction* llvmOnlyAction = new EmitLLVMOnlyAction(llvmContext.get());
+            codeGenAction = llvmOnlyAction;
+            // Make act the owning ptr
+            act = std::unique_ptr<FrontendAction>(llvmOnlyAction);
+        }
+        else
+        {
+            act = CreateFrontendAction(*clang);
+        }
+
+        if (!act)
+        {
+            return SLANG_FAIL;
+        }
+
+        const bool compileSucceeded = clang->ExecuteAction(*act);
+
+        // If the compilation failed make sure, we have an error
+        if (!compileSucceeded)
+        {
+            diagsBuffer.m_diagnostics.requireErrorDiagnostic();
+        }
+
+        if (!compileSucceeded || diagsBuffer.hasError())
+        {
+            outResult = new BlobDownstreamCompileResult(diagsBuffer.m_diagnostics, nullptr);
+            return SLANG_FAIL;
+        }
+    }
+
+    std::unique_ptr<llvm::Module> module;
+
+    switch (action)
+    {
+        case frontend::ActionKind::EmitLLVM:
+        {
+            // LLVM output is text, that must be zero terminated
+            output.push_back(char(0));
+
+            StringRef identifier;
+            StringRef data(output.begin(), output.size() - 1);
+
+            MemoryBufferRef memoryBufferRef(data, identifier);
+
+            SMDiagnostic err;
+            module = llvm::parseIR(memoryBufferRef, err, *llvmContext);
+            break;
+        }
+        case frontend::ActionKind::EmitBC:
+        {
+            StringRef identifier;
+            StringRef data(output.begin(), output.size());
+
+            MemoryBufferRef memoryBufferRef(data, identifier);
+
+            SMDiagnostic err;
+            module = llvm::parseIR(memoryBufferRef, err, *llvmContext);
+            break;
+        }
+        case frontend::ActionKind::EmitLLVMOnly:
+        {
+            // Get the module produced by the action
+            module = codeGenAction->takeModule();
+            break;
+        }
+    }
+
+    switch (options.targetType)
+    {
+        case SLANG_HOST_CALLABLE:
+        {
+            // Try running something in the module on the JIT
+            std::unique_ptr<llvm::orc::LLJIT> jit;
+            {
+                // Create the JIT
+
+                LLJITBuilder jitBuilder;
+
+                Expected<std::unique_ptr< llvm::orc::LLJIT>> expectJit = jitBuilder.create();
+                if (!expectJit)
+                {
+                    return SLANG_FAIL;
+                }
+                jit = std::move(*expectJit);
+            }
+
+            // Used the following link to test this out
+            // https://www.llvm.org/docs/ORCv2.html
+            // https://www.llvm.org/docs/ORCv2.html#processandlibrarysymbols
+
+            {
+                auto& es = jit->getExecutionSession();
+
+                const DataLayout& dl = jit->getDataLayout();
+                MangleAndInterner mangler(es, dl);
+
+                // The name of the lib must be unique. Should be here as we are only thing adding libs
+                auto stdcLibExpected = es.createJITDylib("stdc");
+
+                if (stdcLibExpected)
+                {
+                    auto& stdcLib = *stdcLibExpected;
+
+                    // Add all the symbolmap
+                    SymbolMap symbolMap;
+
+                    //symbolMap.insert(std::make_pair(mangler("sin"), JITEvaluatedSymbol::fromPointer(static_cast<double (*)(double)>(&sin))));
+
+                    static const NameAndFunc funcs[] =
+                    {
+                        SLANG_LLVM_FUNCS(SLANG_LLVM_FUNC)
+                    };
+
+                    for (auto& func : funcs)
+                    {
+                        symbolMap.insert(std::make_pair(mangler(func.name), JITEvaluatedSymbol::fromPointer(func.func)));
+                    }
+
+                    stdcLib.define(absoluteSymbols(symbolMap));
+
+                    // Required or the symbols won't be found
+                    jit->getMainJITDylib().addToLinkOrder(stdcLib);
+                }
+            }
+
+            ThreadSafeModule threadSafeModule(std::move(module), std::move(llvmContext));
+
+            jit->addIRModule(std::move(threadSafeModule));
+
+            outResult = new LLVMDownstreamCompileResult(diagsBuffer.m_diagnostics, std::move(jit));
+            return SLANG_OK;
+        }
+    }
+
+    return SLANG_FAIL;
+}
+
+} // namespace slang_clang
+
+extern "C" SLANG_DLL_EXPORT SlangResult createLLVMDownstreamCompiler(Slang::RefPtr<Slang::DownstreamCompiler>&out)
+{
+    return SLANG_FAIL;
+}

--- a/source/slang-llvm/slang-llvm.cpp
+++ b/source/slang-llvm/slang-llvm.cpp
@@ -238,7 +238,7 @@ public:
         m_diagnostics.diagnostics.add(diagnostic);
     }
 
-    bool hasError() const { return m_diagnostics.getCountByMinSeverity(DownstreamDiagnostic::Severity::Error) > 0; }
+    bool hasError() const { return m_diagnostics.getCountAtLeastSeverity(DownstreamDiagnostic::Severity::Error) > 0; }
 
     DownstreamDiagnostics m_diagnostics;
 };
@@ -647,6 +647,7 @@ SlangResult LLVMDownstreamCompiler::compile(const CompileOptions& options, RefPt
         if (!compileSucceeded)
         {
             diagsBuffer.m_diagnostics.requireErrorDiagnostic();
+            diagsBuffer.m_diagnostics.result = SLANG_FAIL;
         }
 
         if (!compileSucceeded || diagsBuffer.hasError())

--- a/source/slang-llvm/slang-llvm.cpp
+++ b/source/slang-llvm/slang-llvm.cpp
@@ -296,6 +296,7 @@ static void assertFailed(const char* msg)
     x(F64_ceil, ceil, double, (double)) \
     x(F64_floor, floor, double, (double)) \
     x(F64_round, round, double, (double)) \
+    x(F64_abs, fabs, double, (double)) \
     x(F64_sin, sin, double, (double)) \
     x(F64_cos, cos, double, (double)) \
     x(F64_tan, tan, double, (double)) \
@@ -330,6 +331,7 @@ static void assertFailed(const char* msg)
     x(F32_ceil, ceilf, float, (float)) \
     x(F32_floor, floorf, float, (float)) \
     x(F32_round, roundf, float, (float)) \
+    x(F32_abs, fabsf, float, (float)) \
     x(F32_sin, sinf, float, (float)) \
     x(F32_cos, cosf, float, (float)) \
     x(F32_tan, tanf, float, (float)) \
@@ -665,13 +667,13 @@ SlangResult LLVMDownstreamCompiler::compile(const CompileOptions& options, RefPt
         if (!compileSucceeded)
         {
             diagsBuffer.m_diagnostics.requireErrorDiagnostic();
-            diagsBuffer.m_diagnostics.result = SLANG_FAIL;
         }
-
+        
         if (!compileSucceeded || diagsBuffer.hasError())
         {
+            diagsBuffer.m_diagnostics.result = SLANG_FAIL;
             outResult = new BlobDownstreamCompileResult(diagsBuffer.m_diagnostics, nullptr);
-            return SLANG_FAIL;
+            return SLANG_OK;
         }
     }
 
@@ -714,6 +716,8 @@ SlangResult LLVMDownstreamCompiler::compile(const CompileOptions& options, RefPt
 
     switch (options.targetType)
     {
+        // TODO(JS): Shared library may not be appropriate, but as long as the 'shared library' is never accessed as a blob
+        // all is good.
         case SLANG_SHARED_LIBRARY:
         case SLANG_HOST_CALLABLE:
         {


### PR DESCRIPTION
There was an odd problem where the LLVM JIT would work with slang (as the backend C++ compiler and used for the host-callable), but only if LLVM was build as debug.

The issue appears to be due the premake automatically linking against all LLVM libraries, by looking in the lib directory. This led it to link against LLVM-C. LLVM-C builds as a shared library *even if* LLVM is build as 'static'. If a LLVM-C can be found by Slang (which it could because I had LLVM installed elsewhere), then the JIT is not constructable.

The major fix here was to stop premake including LLVM-C. 

Other changes here:

* Simplified clang-direct example
* Provide diagnostics if the JIT can't be constructed
* Some comments to try and hightlight the issue.

On doing some simple testing running slang-test on only cpu tests, shows at least 25x speed up over using Visual Studio as the backend.  
