### PR TITLE
Use LLVM without tinfo requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,13 @@ Once this repo has been cloned, it is neccessary to get the dependencies needed 
 
 ## Requirements
 
-On Ubuntu 18.04 zlib may need to be installed...
+Ubuntu zlib may need to be installed...
 
 ```
 sudo apt-get install zlib1g-dev
 ```
 
 If zlib isn't available `-lz` on the link command line will fail.
-
-zlib appears to be installed by default on Ubuntu 20.04
 
 ## Premake
 
@@ -44,7 +42,7 @@ Slang-llvm uses the tool [`premake5`](https://premake.github.io/) in order to ge
 premake vs2019 --deps=true
 ```
 
-By default this assumes building for `x86_64`. If some other target is required it can be set via the `--arch` option. NOTE! This might seem unrequired by Visual Studio as it is possible to vary the 'platform' - the arch must be set to the desired platform, as any binaries (such as LLVM!) will only be available for the value specified in `--arch`. For example to build for x86
+By default this assumes building for `x86_64`. If some other target is required it can be set via the `--arch` option. NOTE! This might seem unrequired by Visual Studio as it is possible to vary the 'platform' in the IDE. In this case though arch must be set to the desired platform, as any binaries (such as LLVM!) will only be available for the value specified in `--arch`. For example to build for x86
 
 ```
 premake vs2019 --deps=true --arch=x86

--- a/deps/target-deps.json
+++ b/deps/target-deps.json
@@ -4,13 +4,13 @@
         "dependencies" : [
             {
                 "name" : "llvm",
-                "baseUrl" : "https://github.com/shader-slang/llvm-project/releases/download/slang-tot-23/",
+                "baseUrl" : "https://github.com/shader-slang/llvm-project/releases/download/slang-tot-24/",
                 "packages" : 
                 {
-                    "windows-x86_64" : "llvm-tot-23-win64-Release.zip",
-                    "windows-x86" : "llvm-tot-23-win32-Release.zip",
-                    "linux-x86_64" : "llvm-tot-23-linux-x86_64-Release.zip",
-                    "macosx-x86_64" : "llvm-tot-23-macosx-x86_64-Release.zip"
+                    "windows-x86_64" : "llvm-tot-24-win64-Release.zip",
+                    "windows-x86" : "llvm-tot-24-win32-Release.zip",
+                    "linux-x86_64" : "llvm-tot-24-linux-x86_64-Release.zip",
+                    "macosx-x86_64" : "llvm-tot-24-macosx-x86_64-Release.zip"
                 }
             },
             {

--- a/deps/target-deps.json
+++ b/deps/target-deps.json
@@ -4,13 +4,13 @@
         "dependencies" : [
             {
                 "name" : "llvm",
-                "baseUrl" : "https://github.com/shader-slang/llvm-project/releases/download/slang-tot-24/",
+                "baseUrl" : "https://github.com/shader-slang/llvm-project/releases/download/slang-tot-25/",
                 "packages" : 
                 {
-                    "windows-x86_64" : "llvm-tot-24-win64-Release.zip",
-                    "windows-x86" : "llvm-tot-24-win32-Release.zip",
-                    "linux-x86_64" : "llvm-tot-24-linux-x86_64-Release.zip",
-                    "macosx-x86_64" : "llvm-tot-24-macosx-x86_64-Release.zip"
+                    "windows-x86_64" : "llvm-tot-25-win64-Release.zip",
+                    "windows-x86" : "llvm-tot-25-win32-Release.zip",
+                    "linux-x86_64" : "llvm-tot-25-linux-x86_64-Release.zip",
+                    "macosx-x86_64" : "llvm-tot-25-macosx-x86_64-Release.zip"
                 }
             },
             {

--- a/premake5.lua
+++ b/premake5.lua
@@ -289,7 +289,7 @@ workspace "slang-llvm"
     filter { "system:linux" }
         buildoptions { "-fno-semantic-interposition", "-ffunction-sections", "-fdata-sections" }
         -- z is for zlib support
-        -- tinfo is for terminal info
+        -- Note that tinfo is not currently required (as is disabled for linux in llvm-project)
         links { "pthread", "stdc++", "dl", "rt", "z" }
         linkoptions{  "-Wl,-rpath,'$$ORIGIN',--no-as-needed,--no-undefined,--start-group" }
                  
@@ -528,7 +528,7 @@ example "link-check"
     -- We need to vary this depending on type
     local libPath = getLLVMLibraryPath(targetInfo, llvmBuildPath, "Release")
     libdirs { libPath }
-    links { "LLVMSupport", "LLVMDemangle" } --, "tinfo"} -- "rt", 
+    links { "LLVMSupport", "LLVMDemangle" } 
 
     -- buildoptions { "-fno-semantic-interposition", "-ffunction-sections", "-fdata-sections" }
 

--- a/premake5.lua
+++ b/premake5.lua
@@ -257,9 +257,6 @@ workspace "slang-llvm"
     filter { "platforms:aarch64"}
         architecture "ARM"
 
-    filter { "platforms:x86", "system:windows" }
-        toolset "clang"
-
     filter { "toolset:clang or gcc*" }  
         buildoptions { "-fvisibility=hidden" } 
         -- Warnings

--- a/premake5.lua
+++ b/premake5.lua
@@ -257,6 +257,9 @@ workspace "slang-llvm"
     filter { "platforms:aarch64"}
         architecture "ARM"
 
+    filter { "platforms:x86", "system:windows" }
+        toolset "clang"
+
     filter { "toolset:clang or gcc*" }  
         buildoptions { "-fvisibility=hidden" } 
         -- Warnings

--- a/premake5.lua
+++ b/premake5.lua
@@ -260,7 +260,7 @@ workspace "slang-llvm"
     filter { "toolset:clang or gcc*" }  
         buildoptions { "-fvisibility=hidden" } 
         -- Warnings
-        buildoptions { "-Wno-unused-parameter", "-Wno-type-limits", "-Wno-sign-compare", "-Wno-unused-variable", "-Wno-reorder", "-Wno-switch", "-Wno-return-type", "-Wno-unused-local-typedefs", "-Wno-parentheses", "-Wno-ignored-optimization-argument", "-Wno-unknown-warning-option", "-Wno-class-memaccess", "-Wno-error", "-Wno-error=comment"} 
+        buildoptions { "-Wno-unused-parameter", "-Wno-type-limits", "-Wno-sign-compare", "-Wno-unused-variable", "-Wno-reorder", "-Wno-switch", "-Wno-return-type", "-Wno-unused-local-typedefs", "-Wno-parentheses", "-Wno-ignored-optimization-argument", "-Wno-unknown-warning-option", "-Wno-class-memaccess", "-Wno-error", "-Wno-error=comment", "-Wno-redundant-move", "-Wno-comment"} 
         
     filter { "toolset:gcc*"}
         buildoptions { "-Wno-unused-but-set-variable", "-Wno-implicit-fallthrough"  }
@@ -290,7 +290,7 @@ workspace "slang-llvm"
         buildoptions { "-fno-semantic-interposition", "-ffunction-sections", "-fdata-sections" }
         -- z is for zlib support
         -- tinfo is for terminal info
-        links { "pthread", "tinfo", "stdc++", "dl", "rt", "z" }
+        links { "pthread", "stdc++", "dl", "rt", "z" }
         linkoptions{  "-Wl,-rpath,'$$ORIGIN',--no-as-needed,--no-undefined,--start-group" }
                  
                  


### PR DESCRIPTION
* Update slang-llvm dep to use linux version that doesn't have tinfo requirement
* Small doc updates
* Remove tinfo from link